### PR TITLE
Guard nav observer from missing sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,7 +3,10 @@ document.getElementById('year').textContent = new Date().getFullYear()
 
 // Nav active on scroll
 const links = [...document.querySelectorAll('.nav a')]
-const sections = links.map(a => document.querySelector(a.getAttribute('href')))
+// Only observe sections that actually exist in the document to avoid runtime errors
+const sections = links
+  .map(a => document.querySelector(a.getAttribute('href')))
+  .filter(Boolean)
 const obs = new IntersectionObserver((entries)=>{
   entries.forEach(e=>{
     if(e.isIntersecting){


### PR DESCRIPTION
## Summary
- prevent runtime errors by filtering missing sections before observing them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4942c2ca083258a85729601ee318a